### PR TITLE
Linking to Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ A fork of the deprecated linuxserver.io tt-rss container. Uses latest master of
 tt-rss when built and rebuilds are triggered when commits are added to the
 tt-rss master branch or the base container is updated.
 
+Find the Image on Docker Hub: [https://hub.docker.com/r/lunik1/tt-rss](https://hub.docker.com/r/lunik1/tt-rss)
+
 NOT supported or endorsed by the linuxserver.io team.
 
 ## Usage


### PR DESCRIPTION
Adding link to Docker Hub.

The Name of the Image on Docker Hub isn't the same as the repository (without docker-). This is a bit confusing.