### PR TITLE
Support tt-rss environment-based configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ RUN \
  rm -rf \
 	/tmp/*
 
+RUN \
+ echo "**** configure php ****" && \
+ sed -i 's/^;clear_env/clear_env/i' /etc/php7/php-fpm.d/www.conf
+
 # copy local files
 COPY root/ /
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -45,6 +45,10 @@ RUN \
  rm -rf \
 	/tmp/*
 
+RUN \
+ echo "**** configure php ****" && \
+ sed -i 's/^;clear_env/clear_env/i' /etc/php7/php-fpm.d/www.conf
+
 # copy local files
 COPY root/ /
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -45,6 +45,10 @@ RUN \
  rm -rf \
 	/tmp/*
 
+RUN \
+ echo "**** configure php ****" && \
+ sed -i 's/^;clear_env/clear_env/i' /etc/php7/php-fpm.d/www.conf
+
 # copy local files
 COPY root/ /
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-A fork of the deprecated linuxserver.io tt-rss container. Uses latest master of
-tt-rss when built and rebuilds are triggered when commits are added to the
-tt-rss master branch or the base container is updated.
+A fork of the deprecated linuxserver.io tt-rss container. Uses latest master of tt-rss when built and rebuilds are triggered when commits are added to the tt-rss master branch or the base container is updated.
 
 Find the Image on Docker Hub: [https://hub.docker.com/r/lunik1/tt-rss](https://hub.docker.com/r/lunik1/tt-rss)
 
@@ -73,14 +71,16 @@ You must create a user and database for tt-rss to use in a mysql/mariadb or post
 
 **The default username and password after initial configuration is admin/password**
 
-## Power users
-The container can configure itself using environment variables, the gaurd for this logic to run is if the variable `DB_TYPE` is set. The most common variables to set are a URL for the application and a database endpoint. IE:
-* -e DB_TYPE=mysql
-* -e DB_HOST=host
-* -e DB_USER=user
-* -e DB_NAME=name
-* -e DB_PASS=password
-* -e DB_PORT=3306
-* -e SELF_URL_PATH=http://localhost/
+## Application Configuration
+The container can configure itself using environment variables, this is now preferred over using `config.php`. The most common variables to set are a URL for the application and a database endpoint. IE:
+* -e TTRSS_DB_TYPE=mysql
+* -e TTRSS_DB_HOST=host
+* -e TTRSS_DB_USER=user
+* -e TTRSS_DB_NAME=name
+* -e TTRSS_DB_PASS=password
+* -e TTRSS_DB_PORT=3306
+* -e TTRSS_SELF_URL_PATH=http://localhost/
 
-Please note if you use this method you need to have an already initialized database endpoint.
+For a full list of supported variables and their defaults see [here](https://git.tt-rss.org/fox/tt-rss/src/branch/master/classes/config.php#L57).
+
+Please note you need to have an already initialized database endpoint.

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,9 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-# if this is a legacy container do not run any logic
-[[ -d /config/www/tt-rss ]] && \
-	exit 0
-
 # create symlinks
 symlinks=( \
 /var/www/html/config.php \
@@ -25,48 +21,43 @@ for i in "${symlinks[@]}"; do
 		ln -s /config/"$(basename "$i")" "$i"
 done
 
-# config.php file setup
-if [ "${DB_TYPE+x}" ]; then
-	echo "DB_TYPE set, injecting env variables into config.php"
-	if [ ! -f /config/config.php ]; then
-		echo "Creating config.php from the dist file"
-		cp /var/www/html/config.php-dist /config/config.php
-		ln -s /config/config.php /var/www/html/config.php
-	fi
-	[[ "${DB_TYPE+x}" ]] && sed -i "s|\s*define('DB_TYPE',.*|\tdefine('DB_TYPE', '$DB_TYPE');|g" /config/config.php
-	[[ "${DB_HOST+x}" ]] && sed -i "s|\s*define('DB_HOST',.*|\tdefine('DB_HOST', '$DB_HOST');|g" /config/config.php
-	[[ "${DB_USER+x}" ]] && sed -i "s|\s*define('DB_USER',.*|\tdefine('DB_USER', '$DB_USER');|g" /config/config.php
-	[[ "${DB_NAME+x}" ]] && sed -i "s|\s*define('DB_NAME',.*|\tdefine('DB_NAME', '$DB_NAME');|g" /config/config.php
-	[[ "${DB_PASS+x}" ]] && sed -i "s|\s*define('DB_PASS',.*|\tdefine('DB_PASS', '$DB_PASS');|g" /config/config.php
-	[[ "${DB_PORT+x}" ]] && sed -i "s|\s*define('DB_PORT',.*|\tdefine('DB_PORT', '$DB_PORT');|g" /config/config.php
-	[[ "${MYSQL_CHARSET+x}" ]] && sed -i "s|\s*define('MYSQL_CHARSET',.*|\tdefine('MYSQL_CHARSET', '$MYSQL_CHARSET');|g" /config/config.php
-	[[ "${SELF_URL_PATH+x}" ]] && sed -i "s|\s*define('SELF_URL_PATH',.*|\tdefine('SELF_URL_PATH', '$SELF_URL_PATH');|g" /config/config.php
-	[[ "${SINGLE_USER_MODE+x}" ]] && sed -i "s|\s*define('SINGLE_USER_MODE',.*|\tdefine('SINGLE_USER_MODE', $SINGLE_USER_MODE);|g" /config/config.php
-	[[ "${SIMPLE_UPDATE_MODE+x}" ]] && sed -i "s|\s*define('SIMPLE_UPDATE_MODE',.*|\tdefine('SIMPLE_UPDATE_MODE', $SIMPLE_UPDATE_MODE);|g" /config/config.php
-	[[ "${PHP_EXECUTABLE+x}" ]] && sed -i "s|\s*define('PHP_EXECUTABLE',.*|\tdefine('PHP_EXECUTABLE', '$PHP_EXECUTABLE');|g" /config/config.php
-	[[ "${LOCK_DIRECTORY+x}" ]] && sed -i "s|\s*define('LOCK_DIRECTORY',.*|\tdefine('LOCK_DIRECTORY', '$LOCK_DIRECTORY');|g" /config/config.php
-	[[ "${CACHE_DIR+x}" ]] && sed -i "s|\s*define('CACHE_DIR',.*|\tdefine('CACHE_DIR', '$CACHE_DIR');|g" /config/config.php
-	[[ "${ICONS_DIR+x}" ]] && sed -i "s|\s*define('ICONS_DIR',.*|\tdefine('ICONS_DIR', '$ICONS_DIR');|g" /config/config.php
-	[[ "${ICONS_URL+x}" ]] && sed -i "s|\s*define('ICONS_URL',.*|\tdefine('ICONS_URL', '$ICONS_URL');|g" /config/config.php
-	[[ "${AUTH_AUTO_CREATE+x}" ]] && sed -i "s|\s*define('AUTH_AUTO_CREATE',.*|\tdefine('AUTH_AUTO_CREATE', $AUTH_AUTO_CREATE);|g" /config/config.php
-	[[ "${AUTH_AUTO_LOGIN+x}" ]] && sed -i "s|\s*define('AUTH_AUTO_LOGIN',.*|\tdefine('AUTH_AUTO_LOGIN', $AUTH_AUTO_LOGIN);|g" /config/config.php
-	[[ "${FORCE_ARTICLE_PURGE+x}" ]] && sed -i "s|\s*define('FORCE_ARTICLE_PURGE',.*|\tdefine('FORCE_ARTICLE_PURGE', '$FORCE_ARTICLE_PURGE');|g" /config/config.php
-	[[ "${SPHINX_SERVER+x}" ]] && sed -i "s|\s*define('SPHINX_SERVER',.*|\tdefine('SPHINX_SERVER', '$SPHINX_SERVER');|g" /config/config.php
-	[[ "${SPHINX_INDEX+x}" ]] && sed -i "s|\s*define('SPHINX_INDEX',.*|\tdefine('SPHINX_INDEX', '$SPHINX_INDEX');|g" /config/config.php
-	[[ "${ENABLE_REGISTRATION+x}" ]] && sed -i "s|\s*define('ENABLE_REGISTRATION',.*|\tdefine('ENABLE_REGISTRATION', $ENABLE_REGISTRATION);|g" /config/config.php
-	[[ "${REG_NOTIFY_ADDRESS+x}" ]] && sed -i "s|\s*define('REG_NOTIFY_ADDRESS',.*|\tdefine('REG_NOTIFY_ADDRESS', '$REG_NOTIFY_ADDRESS');|g" /config/config.php
-	[[ "${REG_MAX_USERS+x}" ]] && sed -i "s|\s*define('REG_MAX_USERS',.*|\tdefine('REG_MAX_USERS', '$REG_MAX_USERS');|g" /config/config.php
-	[[ "${SESSION_COOKIE_LIFETIME+x}" ]] && sed -i "s|\s*define('SESSION_COOKIE_LIFETIME',.*|\tdefine('SESSION_COOKIE_LIFETIME', '$SESSION_COOKIE_LIFETIME');|g" /config/config.php
-	[[ "${SMTP_FROM_NAME+x}" ]] && sed -i "s|\s*define('SMTP_FROM_NAME',.*|\tdefine('SMTP_FROM_NAME', '$SMTP_FROM_NAME');|g" /config/config.php
-	[[ "${SMTP_FROM_ADDRESS+x}" ]] && sed -i "s|\s*define('SMTP_FROM_ADDRESS',.*|\tdefine('SMTP_FROM_ADDRESS', '$SMTP_FROM_ADDRESS');|g" /config/config.php
-	[[ "${DIGEST_SUBJECT+x}" ]] && sed -i "s|\s*define('DIGEST_SUBJECT',.*|\tdefine('DIGEST_SUBJECT', '$DIGEST_SUBJECT');|g" /config/config.php
-	[[ "${CHECK_FOR_UPDATES+x}" ]] && sed -i "s|\s*define('CHECK_FOR_UPDATES',.*|\tdefine('CHECK_FOR_UPDATES', $CHECK_FOR_UPDATES);|g" /config/config.php
-	[[ "${ENABLE_GZIP_OUTPUT+x}" ]] && sed -i "s|\s*define('ENABLE_GZIP_OUTPUT',.*|\tdefine('ENABLE_GZIP_OUTPUT', $ENABLE_GZIP_OUTPUT);|g" /config/config.php
-	[[ "${PLUGINS+x}" ]] && sed -i "s|\s*define('PLUGINS',.*|\tdefine('PLUGINS', '$PLUGINS');|g" /config/config.php
-	[[ "${LOG_DESTINATION+x}" ]] && sed -i "s|\s*define('LOG_DESTINATION',.*|\tdefine('LOG_DESTINATION', '$LOG_DESTINATION');|g" /config/config.php
-fi
+# translate legacy variables
+printf "${DB_TYPE}" > /var/run/s6/container_environment/TTRSS_DB_TYPE
+printf "${DB_HOST}" > /var/run/s6/container_environment/TTRSS_DB_HOST
+printf "${DB_USER}" > /var/run/s6/container_environment/TTRSS_DB_USER
+printf "${DB_NAME}" > /var/run/s6/container_environment/TTRSS_DB_NAME
+printf "${DB_PASS}" > /var/run/s6/container_environment/TTRSS_DB_PASS
+printf "${DB_PORT}" > /var/run/s6/container_environment/TTRSS_DB_PORT
+printf "${MYSQL_CHARSET}" > /var/run/s6/container_environment/TTRSS_MYSQL_CHARSET
+printf "${SELF_URL_PATH}" > /var/run/s6/container_environment/TTRSS_SELF_URL_PATH
+printf "${SINGLE_USER_MODE}" > /var/run/s6/container_environment/TTRSS_SINGLE_USER_MODE
+printf "${SIMPLE_UPDATE_MODE}" > /var/run/s6/container_environment/TTRSS_SIMPLE_UPDATE_MODE
+printf "${PHP_EXECUTABLE}" > /var/run/s6/container_environment/TTRSS_PHP_EXECUTABLE
+printf "${LOCK_DIRECTORY}" > /var/run/s6/container_environment/TTRSS_LOCK_DIRECTORY
+printf "${CACHE_DIR}" > /var/run/s6/container_environment/TTRSS_CACHE_DIR
+printf "${ICONS_DIR}" > /var/run/s6/container_environment/TTRSS_ICONS_DIR
+printf "${ICONS_URL}" > /var/run/s6/container_environment/TTRSS_ICONS_URL
+printf "${AUTH_AUTO_CREATE}" > /var/run/s6/container_environment/TTRSS_AUTH_AUTO_CREATE
+printf "${AUTH_AUTO_LOGIN}" > /var/run/s6/container_environment/TTRSS_AUTH_AUTO_LOGIN
+printf "${FORCE_ARTICLE_PURGE}" > /var/run/s6/container_environment/TTRSS_FORCE_ARTICLE_PURGE
+printf "${SPHINX_SERVER}" > /var/run/s6/container_environment/TTRSS_SPHINX_SERVER
+printf "${SPHINX_INDEX}" > /var/run/s6/container_environment/TTRSS_SPHINX_INDEX
+printf "${ENABLE_REGISTRATION}" > /var/run/s6/container_environment/TTRSS_ENABLE_REGISTRATION
+printf "${REG_NOTIFY_ADDRESS}" > /var/run/s6/container_environment/TTRSS_REG_NOTIFY_ADDRESS
+printf "${REG_MAX_USERS}" > /var/run/s6/container_environment/TTRSS_REG_MAX_USERS
+printf "${SESSION_COOKIE_LIFETIME}" > /var/run/s6/container_environment/TTRSS_SESSION_COOKIE_LIFETIME
+printf "${SMTP_FROM_NAME}" > /var/run/s6/container_environment/TTRSS_SMTP_FROM_NAME
+printf "${SMTP_FROM_ADDRESS}" > /var/run/s6/container_environment/TTRSS_SMTP_FROM_ADDRESS
+printf "${DIGEST_SUBJECT}" > /var/run/s6/container_environment/TTRSS_DIGEST_SUBJECT
+printf "${CHECK_FOR_UPDATES}" > /var/run/s6/container_environment/TTRSS_CHECK_FOR_UPDATES
+printf "${ENABLE_GZIP_OUTPUT}" > /var/run/s6/container_environment/TTRSS_ENABLE_GZIP_OUTPUT
+printf "${PLUGINS}" > /var/run/s6/container_environment/TTRSS_PLUGINS
+printf "${LOG_DESTINATION}" > /var/run/s6/container_environment/TTRSS_LOG_DESTINATION
 
 # permissions
 chown -R abc:abc \
 	/config \
 	/var/www/html/
+
+# even if using environment, tt-rss needs config.php to at least exist
+touch config/config.php


### PR DESCRIPTION
Previously the environment variables used to configure the container were placed into `config.php`. Now `tt-rss` takes its configuration from the environment, so allow php to read these directly.

The environment variables used by `tt-rss` are the same as those used by this container previously except with a `TTRSS_` prefix. Add some logic to not break containers that are using the old environment variables (but these should be considered deprecated).